### PR TITLE
リリース作成はaction.ymlに差分があったときのみ行う

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - action.yml
 
 jobs:
   create-release:


### PR DESCRIPTION
action自体に変更がないのにリリースが作られるのも無駄なので、リリース作成は `action.yml` に差分があったときのみ行うようにします。