### PR TITLE
update-readmeのトリガー修正

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -3,6 +3,11 @@ name: update-readme
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - closed
   push:
     branches:
       - main


### PR DESCRIPTION
`update-readme` のトリガーが最新の本Actionに対応していなかったので修正します。