### PR TITLE
Replace set-output by $GITHUB_OUTPUT

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
       if: github.event_name != 'pull_request' || github.event.action != 'closed'
       run: |
         result=$(git diff --cached)
-        echo "::set-output name=result::$result"
+        echo "result=$result" >> $GITHUB_OUTPUT
     # 差分があったときは、コミットを作りpushする
     - name: Push
       env:

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
       if: github.event_name != 'pull_request' || github.event.action != 'closed'
       run: |
         result=$(git diff --cached)
-        echo "result=$result" >> $GITHUB_OUTPUT
+        echo "result=$result" >> "${GITHUB_OUTPUT}"
     # 差分があったときは、コミットを作りpushする
     - name: Push
       env:


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
set-output が非推奨になるらしいので `$GITHUB_OUTPUT` に置き換えた

```bash
find . -name '*.yml' -exec sed -i 's/echo "::set-output name=\([a-zA-Z0-9_]*\)::\(.*\)"$/echo "\1=\2" >> $GITHUB_OUTPUT/' {} \;
```