### PR TITLE
差分の改行文字・%をエスケープしてoutputに渡す

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,9 @@ runs:
       if: github.event_name != 'pull_request' || github.event.action != 'closed'
       run: |
         result=$(git diff --cached)
+        result="${result//'%'/'%25'}"
+        result="${result//$'\n'/'%0A'}"
+        result="${result//$'\r'/'%0D'}"
         echo "result=$result" >> "${GITHUB_OUTPUT}"
     # 差分があったときは、コミットを作りpushする
     - name: Push


### PR DESCRIPTION
https://github.com/dev-hato/actions-diff-pr-management/actions/runs/3246450628/jobs/5325200310 ( https://github.com/dev-hato/actions-diff-pr-management/pull/312 )

```
Error: Unable to process file command 'output' successfully.
Error: Invalid format 'index 58eb593..6f65548 100644'
```

上記エラーが発生しないようにエスケープしてみます。
参考: https://gotohayato.com/content/558/