### PR TITLE
CI: PR close時のスキップ処理追加

### DIFF
--- a/.github/workflows/update-gitleaks.yml
+++ b/.github/workflows/update-gitleaks.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.5.2
+        if: github.event_name != 'pull_request' || github.event.action != 'closed'
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -31,7 +32,7 @@ jobs:
       - name: Install packages
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         run: npm ci
-      - uses: dev-hato/actions-update-gitleaks@v0.0.43
+      - uses: dev-hato/actions-update-gitleaks@v0.0.44
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
 


### PR DESCRIPTION
https://github.com/dev-hato/actions-update-gitleaks/pull/846 を受けて追加でPR close時のスキップ処理を追加します。