### PR TITLE
CI 自体を失敗ステータスにするかどうかを利用者側が選択できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ jobs:
 | branch-name-prefix | branch名の接頭語。 |  |
 | pr-title-prefix | PRのタイトルの接頭語。 |  |
 | pr-description-prefix | 本文の接頭語。 |  |
+| exit-failure | 実行完了時にCIを失敗させるかどうか。 |  |
 
 ## 対応しているトリガー
 * pull_request

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: '本文の接頭語。'
     required: true
     default: ""
+  exit-failure:
+    description: '実行完了時にCIを失敗させるかどうか。'
+    required: false
+    default: "true"
 runs:
   using: "composite"
   steps:
@@ -102,6 +106,6 @@ runs:
           const script = require('${{ github.action_path }}/scripts/action/close_pull_request.js')
           await script({github, context})
     - name: Exit
-      if: (github.event_name != 'pull_request' || github.event.action != 'closed') && steps.diff.outputs.result != ''
+      if: (github.event_name != 'pull_request' || github.event.action != 'closed') && steps.diff.outputs.result != '' && inputs.exit-failure == 'true'
       run: exit 1
       shell: bash


### PR DESCRIPTION
当初想定されているユースケースとは外れていると思うけど、
Pull request ベースではないタイミングで差分の有無を確認し
差分があれば Pull request を作成したいため、正常に完了していれば
CI の完了ステータスは成功となってほしい。

Pull request ベースではないタイミング:
具体的には workflow_dispatch 等で外からキックされて、そのタイミングでの差分確認を行なうというユースケースを想定

actions 利用者のユースケースによって最終的なステータス処理が異なるのでフラグで選択できるようにする。