### PR TITLE
git commit, push時に--no-verifyを付与するオプション追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ jobs:
 | pr-description-prefix | 本文の接頭語。 |  |  |
 | exit-failure | 実行完了時にCIを失敗させるかどうか。 |  | true |
 | working-directory | 実行対象のディレクトリ |  |  |
+| no-verify | git commit, push時のフックを無効化する |  | false |
 
 ## 対応しているトリガー
 * pull_request

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: '実行対象のディレクトリ'
     required: false
     default: ""
+  no-verify:
+    description: 'git commit, push時のフックを無効化する'
+    required: false
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -46,6 +50,7 @@ runs:
         TOKEN: ${{inputs.github-token}}
         REPOSITORY: ${{github.repository}}
         BRANCH_NAME_PREFIX: ${{inputs.branch-name-prefix}}
+        NO_VERIFY: ${{inputs.no-verify}}
       if: steps.diff.outputs.result != '' && ((github.event_name == 'pull_request' && github.event.action != 'closed') || github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch')
       working-directory: ${{inputs.working-directory}}
       run: ${{ github.action_path }}/scripts/action/push.sh

--- a/scripts/action/push.sh
+++ b/scripts/action/push.sh
@@ -11,7 +11,6 @@ fi
 
 GIT_COMMIT_COMMAND="$GIT_COMMIT_COMMAND -m \"${PR_TITLE_PREFIX}\""
 eval "$GIT_COMMIT_COMMAND"
-git commit -m "${PR_TITLE_PREFIX}"
 REPO_URL="https://"
 REPO_URL+="${AUTHOR}:${TOKEN}@github.com/"
 REPO_URL+="${REPOSITORY}.git"

--- a/scripts/action/push.sh
+++ b/scripts/action/push.sh
@@ -3,9 +3,24 @@
 git config user.name "github-actions[bot]"
 EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
 git config user.email "${EMAIL}"
+GIT_COMMIT_COMMAND="git commit "
+
+if [ "$NO_VERIFY" = "true" ]; then
+  GIT_COMMIT_COMMAND+="--no-verify "
+fi
+
+GIT_COMMIT_COMMAND+="-m \"${PR_TITLE_PREFIX}\""
+eval "$GIT_COMMIT_COMMAND"
 git commit -m "${PR_TITLE_PREFIX}"
 REPO_URL="https://"
 REPO_URL+="${AUTHOR}:${TOKEN}@github.com/"
 REPO_URL+="${REPOSITORY}.git"
 GITHUB_HEAD="HEAD:refs/heads/${BRANCH_NAME_PREFIX}-${HEAD_REF}"
-git push -f "${REPO_URL}" "${GITHUB_HEAD}"
+GIT_PUSH_COMMAND="git push "
+
+if [ "$NO_VERIFY" = "true" ]; then
+  GIT_PUSH_COMMAND+="--no-verify "
+fi
+
+GIT_PUSH_COMMAND=+"-f \"${REPO_URL}\" \"${GITHUB_HEAD}\""
+eval "$GIT_PUSH_COMMAND"

--- a/scripts/action/push.sh
+++ b/scripts/action/push.sh
@@ -3,24 +3,24 @@
 git config user.name "github-actions[bot]"
 EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
 git config user.email "${EMAIL}"
-GIT_COMMIT_COMMAND="git commit "
+GIT_COMMIT_COMMAND="git commit"
 
 if [ "$NO_VERIFY" = "true" ]; then
-  GIT_COMMIT_COMMAND+="--no-verify "
+  GIT_COMMIT_COMMAND="$GIT_COMMIT_COMMAND --no-verify"
 fi
 
-GIT_COMMIT_COMMAND+="-m \"${PR_TITLE_PREFIX}\""
+GIT_COMMIT_COMMAND="$GIT_COMMIT_COMMAND -m \"${PR_TITLE_PREFIX}\""
 eval "$GIT_COMMIT_COMMAND"
 git commit -m "${PR_TITLE_PREFIX}"
 REPO_URL="https://"
 REPO_URL+="${AUTHOR}:${TOKEN}@github.com/"
 REPO_URL+="${REPOSITORY}.git"
 GITHUB_HEAD="HEAD:refs/heads/${BRANCH_NAME_PREFIX}-${HEAD_REF}"
-GIT_PUSH_COMMAND="git push "
+GIT_PUSH_COMMAND="git push"
 
 if [ "$NO_VERIFY" = "true" ]; then
-  GIT_PUSH_COMMAND+="--no-verify "
+  GIT_PUSH_COMMAND="$GIT_PUSH_COMMAND --no-verify"
 fi
 
-GIT_PUSH_COMMAND=+"-f \"${REPO_URL}\" \"${GITHUB_HEAD}\""
+GIT_PUSH_COMMAND="$GIT_PUSH_COMMAND -f \"${REPO_URL}\" \"${GITHUB_HEAD}\""
 eval "$GIT_PUSH_COMMAND"


### PR DESCRIPTION
git commit, push時に `--no-verify` オプション (hookを実行しないようにする) を付与するオプションを追加します。