### PR TITLE
PR番号取得処理をGitHub Actionsの変数で取得する

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -71,6 +71,7 @@ runs:
       id: create_pull_request
       env:
         PR_DESCRIPTION_PREFIX: ${{inputs.pr-description-prefix}}
+        PR_NUMBER: ${{github.event.pull_request.number}}
         PR_TITLE_PREFIX: ${{inputs.pr-title-prefix}}
         BRANCH_NAME_PREFIX: ${{inputs.branch-name-prefix}}
       with:

--- a/scripts/action/create_pull_request.js
+++ b/scripts/action/create_pull_request.js
@@ -1,7 +1,7 @@
 module.exports = async ({ github, context }) => {
   const HEAD_REF = process.env.HEAD_REF
   const escapedHeadRef = HEAD_REF.replaceAll('#', '')
-  const PR_NUMBER = context.payload.number
+  const PR_NUMBER = process.env.PR_NUMBER
   const PR_TITLE_PREFIX = process.env.PR_TITLE_PREFIX
   let head = process.env.BRANCH_NAME_PREFIX
 


### PR DESCRIPTION
PR番号取得処理がうまくいっていないので ( https://github.com/dev-hato/sudden-death/pull/2106 ) PR番号のみGitHub Actionsの変数で取得するようにします。