### PR TITLE
textlint-rule-terminologyアップデート

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ jobs:
 | pr-description-prefix | 本文の接頭語。 |  |  |
 | exit-failure | 実行完了時にCIを失敗させるかどうか。 |  | true |
 | working-directory | 実行対象のディレクトリ |  |  |
-| no-verify | git commit, push時のフックを無効化する |  | false |
+| no-verify | `git commit`, `git push` 時のフックを無効化する |  | false |
 
 ## 対応しているトリガー
 * pull_request

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
     required: false
     default: ""
   no-verify:
-    description: 'git commit, push時のフックを無効化する'
+    description: '`git commit`, `git push` 時のフックを無効化する'
     required: false
     default: "false"
 runs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "textlint-rule-prefer-tari-tari": "1.0.3",
         "textlint-rule-preset-ja-spacing": "2.4.3",
         "textlint-rule-preset-ja-technical-writing": "10.0.1",
-        "textlint-rule-terminology": "5.0.15"
+        "textlint-rule-terminology": "5.0.17"
       }
     },
     "node_modules/@azu/format-text": {
@@ -5959,9 +5959,9 @@
       }
     },
     "node_modules/textlint-rule-terminology": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/textlint-rule-terminology/-/textlint-rule-terminology-5.0.15.tgz",
-      "integrity": "sha512-mdcKh7LVMUPlUbGeCai/PUwUVH5ZfutpbN/KuUBmCle55vhUDSKTeiSJFoN82TpSt/Y3F54pkje+jgqLA38JBA==",
+      "version": "5.0.17",
+      "resolved": "https://registry.npmjs.org/textlint-rule-terminology/-/textlint-rule-terminology-5.0.17.tgz",
+      "integrity": "sha512-rbWloJT6GPo20x8+gz0gcaSwa5V0B9BSU0uo7ECjhEEN0I2D6jnBpWUvB8P0jXzMAaW6Th5YFsYgmgoiepg4Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "textlint-rule-prefer-tari-tari": "1.0.3",
     "textlint-rule-preset-ja-spacing": "2.4.3",
     "textlint-rule-preset-ja-technical-writing": "10.0.1",
-    "textlint-rule-terminology": "5.0.15"
+    "textlint-rule-terminology": "5.0.17"
   }
 }


### PR DESCRIPTION
https://github.com/dev-hato/actions-diff-pr-management/pull/1620 をアップデートします。
`textlint-rule-terminology` による指摘事項の修正もおこなっています。