### PR TITLE
textlint-rule-general-novel-style-ja削除

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -9,12 +9,6 @@
     },
     "abbr-within-parentheses": true,
     "footnote-order": true,
-    "general-novel-style-ja": {
-        // 各段落の先頭に許可する文字 (false: チェックしない)
-        "chars_leading_paragraph": false,
-        // アラビア数字の桁数は2桁まで (false: チェックしない)
-        "max_arabic_numeral_digits": false
-    },
     "ja-hiragana-fukushi": true,
     "ja-hiragana-hojodoushi": true,
     "ja-hiragana-keishikimeishi": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "textlint-filter-rule-comments": "1.2.2",
         "textlint-rule-abbr-within-parentheses": "1.0.2",
         "textlint-rule-footnote-order": "1.0.3",
-        "textlint-rule-general-novel-style-ja": "dev-hato/textlint-rule-general-novel-style-ja-markdown",
         "textlint-rule-ja-hiragana-fukushi": "1.3.0",
         "textlint-rule-ja-hiragana-hojodoushi": "1.1.0",
         "textlint-rule-ja-hiragana-keishikimeishi": "1.1.0",
@@ -3902,13 +3901,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/kansuji": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/kansuji/-/kansuji-1.1.0.tgz",
-      "integrity": "sha512-zw+QQSoH/nLvm5yJVPUY6kCP9lDSfVxO8poib8lOwruHqxOUZgKzMEdog1/PAen4G8ppoMulffzeVfCGgHgyhw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/keyv": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.2.3.tgz",
@@ -6214,53 +6206,6 @@
       "integrity": "sha512-HH4AWGi05S88XJ0HTzihOpVPDV+BRpnqt/MXnVcQBHTc6wGxNgVoBWN19o43G3D8m3GYnoUAR8UF/IbAYbKolA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/textlint-rule-general-novel-style-ja": {
-      "version": "1.3.0",
-      "resolved": "git+ssh://git@github.com/dev-hato/textlint-rule-general-novel-style-ja-markdown.git#ff32d5297fa6162bef3307e4769234181354253b",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "kansuji": "^1.1.0",
-        "textlint-rule-helper": "^1.1.5"
-      }
-    },
-    "node_modules/textlint-rule-general-novel-style-ja/node_modules/textlint-rule-helper": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
-      "integrity": "sha512-yJmVbmyuUPOndKsxOijpx/G7mwybXXf4M10U2up0BeIZSN+6drUl+aSKAoC+RUHY7bG4ogLwRcmWoNG1lSrRIQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-visit": "^1.1.0"
-      }
-    },
-    "node_modules/textlint-rule-general-novel-style-ja/node_modules/unist-util-is": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/textlint-rule-general-novel-style-ja/node_modules/unist-util-visit": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-visit-parents": "^2.0.0"
-      }
-    },
-    "node_modules/textlint-rule-general-novel-style-ja/node_modules/unist-util-visit-parents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-is": "^3.0.0"
-      }
     },
     "node_modules/textlint-rule-helper": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "textlint-filter-rule-comments": "1.2.2",
     "textlint-rule-abbr-within-parentheses": "1.0.2",
     "textlint-rule-footnote-order": "1.0.3",
-    "textlint-rule-general-novel-style-ja": "dev-hato/textlint-rule-general-novel-style-ja-markdown",
     "textlint-rule-ja-hiragana-fukushi": "1.3.0",
     "textlint-rule-ja-hiragana-hojodoushi": "1.1.0",
     "textlint-rule-ja-hiragana-keishikimeishi": "1.1.0",


### PR DESCRIPTION
`textlint-rule-general-novel-style-ja` は2016年以来更新されていないものに独自の拡張を加えた形 ( https://github.com/dev-hato/textlint-rule-general-novel-style-ja-markdown ) で使用しています。
しかし、自分が使用している設定として示す際にやりづらさを感じたというのと、独自の拡張をしてまで適用する必要があるのか微妙に感じたので、 `textlint-rule-general-novel-style-ja` を削除します。