### PR TITLE
super-linterアップデート

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -5,18 +5,14 @@ env:
   es6: true
   jest: true
   node: true
-
 extends:
   - "eslint:recommended"
-
 ignorePatterns:
   - "!.*"
   - "**/node_modules/.*"
-
 plugins:
   - n
   - prettier
-
 overrides:
   # JSON files
   - files:
@@ -26,7 +22,6 @@ overrides:
     parser: jsonc-eslint-parser
     parserOptions:
       jsonSyntax: JSON
-
   # JSONC files
   - files:
       - "*.jsonc"
@@ -35,7 +30,6 @@ overrides:
     parser: jsonc-eslint-parser
     parserOptions:
       jsonSyntax: JSONC
-
   # JSON5 files
   - files:
       - "*.json5"
@@ -44,7 +38,6 @@ overrides:
     parser: jsonc-eslint-parser
     parserOptions:
       jsonSyntax: JSON5
-
   # Javascript files
   - files:
       - "**/*.js"
@@ -59,7 +52,6 @@ overrides:
       ecmaFeatures:
         jsx: true
         modules: true
-
   # TypeScript files
   - files:
       - "**/*.ts"

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,81 @@
+---
+# https://github.com/super-linter/super-linter/blob/d0b304a6a58b560749c679157953fec8ba7206df/TEMPLATES/.eslintrc.yml
+env:
+  browser: true
+  es6: true
+  jest: true
+  node: true
+
+extends:
+  - "eslint:recommended"
+
+ignorePatterns:
+  - "!.*"
+  - "**/node_modules/.*"
+
+plugins:
+  - n
+  - prettier
+
+overrides:
+  # JSON files
+  - files:
+      - "*.json"
+    extends:
+      - plugin:jsonc/recommended-with-json
+    parser: jsonc-eslint-parser
+    parserOptions:
+      jsonSyntax: JSON
+
+  # JSONC files
+  - files:
+      - "*.jsonc"
+    extends:
+      - plugin:jsonc/recommended-with-jsonc
+    parser: jsonc-eslint-parser
+    parserOptions:
+      jsonSyntax: JSONC
+
+  # JSON5 files
+  - files:
+      - "*.json5"
+    extends:
+      - plugin:jsonc/recommended-with-json5
+    parser: jsonc-eslint-parser
+    parserOptions:
+      jsonSyntax: JSON5
+
+  # Javascript files
+  - files:
+      - "**/*.js"
+      - "**/*.mjs"
+      - "**/*.cjs"
+      - "**/*.jsx"
+    extends:
+      - "plugin:react/recommended"
+    parserOptions:
+      sourceType: module
+      ecmaVersion: latest
+      ecmaFeatures:
+        jsx: true
+        modules: true
+
+  # TypeScript files
+  - files:
+      - "**/*.ts"
+      - "**/*.cts"
+      - "**/*.mts"
+      - "**/*.tsx"
+    extends:
+      - "plugin:@typescript-eslint/recommended"
+      - plugin:n/recommended
+      - plugin:react/recommended
+      - prettier
+    rules:
+      n/no-missing-import: off
+    parser: "@typescript-eslint/parser"
+    plugins:
+      - "@typescript-eslint"
+    parserOptions:
+      ecmaVersion: latest
+      sourceType: module

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -53,7 +53,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@85f7611e0f7b53c8573cca84aa0ed4344f6f6a4d # v7.2.1
+        uses: super-linter/super-linter/slim@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ---
 repos:
   - repo: https://github.com/zricethezav/gitleaks
-    rev: v8.21.2
+    rev: v8.24.0
     hooks:
       - id: gitleaks

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,14 +4,16 @@
   "requires": true,
   "packages": {
     "": {
-      "devDependencies": {
+      "dependencies": {
         "@actions/github": "6.0.0",
         "@octokit/plugin-paginate-rest": "11.4.3",
         "@octokit/plugin-rest-endpoint-methods": "13.3.1",
+        "js-yaml": "4.1.0"
+      },
+      "devDependencies": {
         "@proofdict/textlint-rule-proofdict": "3.1.2",
         "@textlint-ja/textlint-rule-no-insert-dropping-sa": "2.0.1",
         "@types/js-yaml": "4.0.9",
-        "js-yaml": "4.1.0",
         "prettier": "3.5.2",
         "textlint": "14.4.2",
         "textlint-filter-rule-comments": "1.2.2",
@@ -38,7 +40,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@actions/github/-/github-6.0.0.tgz",
       "integrity": "sha512-alScpSVnYmjNEXboZjarjukQEzgCRmjMv6Xj47fsdnqGS73bjJNDpiiXmp8jr0UZLdUB6d9jW63IcmddUP+l0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@actions/http-client": "^2.2.0",
@@ -51,7 +52,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
       "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 18"
@@ -61,7 +61,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
       "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
@@ -80,7 +79,6 @@
       "version": "9.0.6",
       "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
       "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^13.1.0",
@@ -94,7 +92,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
       "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/request": "^8.4.1",
@@ -109,14 +106,12 @@
       "version": "20.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
       "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@actions/github/node_modules/@octokit/plugin-paginate-rest": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
       "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^12.6.0"
@@ -132,7 +127,6 @@
       "version": "12.6.0",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
       "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^20.0.0"
@@ -142,7 +136,6 @@
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
       "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^12.6.0"
@@ -158,7 +151,6 @@
       "version": "12.6.0",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
       "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^20.0.0"
@@ -168,7 +160,6 @@
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
       "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/endpoint": "^9.0.6",
@@ -184,7 +175,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
       "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^13.1.0",
@@ -199,21 +189,18 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@actions/github/node_modules/universal-user-agent": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
       "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/@actions/http-client": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
       "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tunnel": "^0.0.6",
@@ -716,7 +703,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
       "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -897,7 +883,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz",
       "integrity": "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -908,7 +893,6 @@
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.4.tgz",
       "integrity": "sha512-lAS9k7d6I0MPN+gb9bKDt7X8SdxknYqAMh44S5L+lNqIN2NuV8nvv3g8rPp7MuRxcOpxpUIATWprO0C34a8Qmg==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -928,7 +912,6 @@
       "version": "10.1.3",
       "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.3.tgz",
       "integrity": "sha512-nBRBMpKPhQUxCsQQeW+rCJ/OPSMcj3g0nfHn01zGYZXuNDvvXudF/TYY6APj5THlurerpFN4a/dQAIAaM6BYhA==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -943,7 +926,6 @@
       "version": "8.2.1",
       "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.2.1.tgz",
       "integrity": "sha512-n57hXtOoHrhwTWdvhVkdJHdhTv0JstjDbDRhJfwIRNfFqmSo1DaK/mD2syoNUoLCyqSjBpGAKOG0BuwF392slw==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -959,14 +941,12 @@
       "version": "23.0.1",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
       "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@octokit/plugin-paginate-rest": {
       "version": "11.4.3",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.4.3.tgz",
       "integrity": "sha512-tBXaAbXkqVJlRoA/zQVe9mUdb8rScmivqtpv3ovsC5xhje/a+NOCivs7eUhWBwCApJVsR4G5HMeaLbq7PxqZGA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^13.7.0"
@@ -982,7 +962,6 @@
       "version": "13.3.1",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.3.1.tgz",
       "integrity": "sha512-o8uOBdsyR+WR8MK9Cco8dCgvG13H1RlM1nWnK/W7TEACQBFux/vPREgKucxUfuDQ5yi1T3hGf4C5ZmZXAERgwQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^13.8.0"
@@ -998,7 +977,6 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.2.tgz",
       "integrity": "sha512-dZl0ZHx6gOQGcffgm1/Sf6JfEpmh34v3Af2Uci02vzUYz6qEN6zepoRtmybWXIGXFIK8K9ylE3b+duCWqhArtg==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1016,7 +994,6 @@
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.7.tgz",
       "integrity": "sha512-69NIppAwaauwZv6aOzb+VVLwt+0havz9GT5YplkeJv7fG7a40qpLt/yZKyiDxAhgz0EtgNdNcb96Z0u+Zyuy2g==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1030,7 +1007,6 @@
       "version": "13.8.0",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.8.0.tgz",
       "integrity": "sha512-x7DjTIbEpEWXK99DMd01QfWy0hd5h4EN+Q7shkdKds3otGQP+oWE/y0A76i1OvH9fygo4ddvNf7ZvF0t78P98A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^23.0.1"
@@ -1662,7 +1638,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
@@ -1823,7 +1798,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
       "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
-      "dev": true,
       "license": "Apache-2.0",
       "peer": true
     },
@@ -2268,7 +2242,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/diff": {
@@ -2593,7 +2566,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
       "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3890,7 +3862,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4806,7 +4777,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -7878,7 +7848,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -8035,7 +8004,6 @@
       "version": "5.28.5",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
       "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
@@ -8168,7 +8136,6 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
       "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==",
-      "dev": true,
       "license": "ISC",
       "peer": true
     },
@@ -8517,7 +8484,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
-  "devDependencies": {
+  "dependencies": {
     "@actions/github": "6.0.0",
     "@octokit/plugin-paginate-rest": "11.4.3",
     "@octokit/plugin-rest-endpoint-methods": "13.3.1",
+    "js-yaml": "4.1.0"
+  },
+  "devDependencies": {
     "@proofdict/textlint-rule-proofdict": "3.1.2",
     "@textlint-ja/textlint-rule-no-insert-dropping-sa": "2.0.1",
     "@types/js-yaml": "4.0.9",
-    "js-yaml": "4.1.0",
     "prettier": "3.5.2",
     "textlint": "14.4.2",
     "textlint-filter-rule-comments": "1.2.2",


### PR DESCRIPTION
https://github.com/dev-hato/actions-diff-pr-management/pull/1900 をベースにsuper-linterをアップデートします。
`n/no-unpublished-import` に引っかからないよう、スクリプト内でimportしているパッケージを `dependencies` に移動し、 `n/no-missing-import` については解決が難しそうなので一旦無効化しています。