### PR TITLE
super-linterのWarning修正

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -44,8 +44,8 @@ overrides:
       - "**/*.mjs"
       - "**/*.cjs"
       - "**/*.jsx"
-    extends:
-      - "plugin:react/recommended"
+    #extends:
+    #  - "plugin:react/recommended"
     parserOptions:
       sourceType: module
       ecmaVersion: latest
@@ -61,7 +61,7 @@ overrides:
     extends:
       - "plugin:@typescript-eslint/recommended"
       - plugin:n/recommended
-      - plugin:react/recommended
+      #- plugin:react/recommended
       - prettier
     rules:
       n/no-missing-import: off

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -58,7 +58,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: main
           LINTER_RULES_PATH: .
-          TYPESCRIPT_DEFAULT_STYLE: prettier
           VALIDATE_TYPESCRIPT_STANDARD: false
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -1,0 +1,8 @@
+// https://github.com/super-linter/super-linter/blob/5d6e3fcecc2b2906eedc2d15495fd6027bf51a9e/commitlint.config.js
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  helpUrl: "https://www.conventionalcommits.org/",
+  // We need this until https://github.com/dependabot/dependabot-core/issues/2445
+  // is resolved.
+  ignores: [(msg: string) => /Signed-off-by: dependabot\[bot]/m.test(msg)],
+};


### PR DESCRIPTION
以下のWarningを修正します。

https://github.com/dev-hato/actions-diff-pr-management/actions/runs/13726643353/job/38394555555#step:6:149

```
  2025-03-07 18:11:45 [WARN]   Git commit message validation with commitlint is enabled, but no commitlint configuration file is available. Disabling commitlint. To suppress this message, either disable Git commit validation by setting VALIDATE_GIT_COMMITLINT to false in your Super-linter configuration, or provide a commitlint configuration file.
  2025-03-07 18:11:45 [WARN]   TYPESCRIPT_DEFAULT_STYLE environment variable is set, it's deprecated, and super-linter will ignore it. Remove it from your configuration. This warning may turn in a fatal error in the future. For more information, see the upgrade guide: https://github.com/super-linter/super-linter/blob/main/docs/upgrade-guide.md
```

https://github.com/dev-hato/actions-diff-pr-management/actions/runs/13726643353/job/38394555555#step:6:304

```
  Warning: React version not specified in eslint-plugin-react settings. See https://github.com/jsx-eslint/eslint-plugin-react#configuration .
```

https://github.com/dev-hato/actions-diff-pr-management/actions/runs/13726643353/job/38394555555#step:6:397

```
  Warning: React version not specified in eslint-plugin-react settings. See https://github.com/jsx-eslint/eslint-plugin-react#configuration .
```