### PR TITLE
Copilotが立てたPRに対して修正PRを出す際はCopilotをAssigneesに入れない

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ runs:
     # 元のPRを出したユーザーを修正PRにアサインする
     - name: Assign a user
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-      if: steps.diff.outputs.result != '' && steps.get_number_of_pull_requests.outputs.result == 0 && github.event_name == 'pull_request' && github.event.action != 'closed' && github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'renovate[bot]'
+      if: steps.diff.outputs.result != '' && steps.get_number_of_pull_requests.outputs.result == 0 && github.event_name == 'pull_request' && github.event.action != 'closed' && github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'renovate[bot]' && github.event.pull_request.user.login != 'Copilot'
       env:
         PR_NUMBER: ${{steps.create_pull_request.outputs.result}}
       with:


### PR DESCRIPTION
https://www.publickey1.jp/blog/25/github_copilot_coding_agentaiissue.html

GitHub Copilot Coding Agentを使うと、CopilotがPRを立ててコーディングを行います。
この際、修正PRのAssigneesにCopilotが入らないようにします。