### PR TITLE
修正PRにラベルを付与できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ jobs:
 |  branch-name-prefix   |               branch名の接頭語。                |      |     fix      |
 |    pr-title-prefix    |             PRのタイトルの接頭語。              |      |     fix      |
 | pr-description-prefix |                 本文の接頭語。                  |      |              |
+|       pr-labels       |  PRに付与するラベル。カンマ区切りで指定する。   |      |              |
 |     exit-failure      |      実行完了時にCIを失敗させるかどうか。       |      |     true     |
 |   working-directory   |             実行対象のディレクトリ              |      |              |
 |       no-verify       | `git commit`, `git push` 時のフックを無効化する |      |    false     |

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: "本文の接頭語。"
     required: false
     default: ""
+  pr-labels:
+    description: "PRに付与するラベル。カンマ区切りで指定する。"
+    required: false
+    default: ""
   exit-failure:
     description: "実行完了時にCIを失敗させるかどうか。"
     required: false
@@ -52,6 +56,7 @@ runs:
 
         echo "PR_NUMBER=${{github.event.pull_request.number}}" >> "$GITHUB_ENV"
         echo "PR_TITLE_PREFIX=${{inputs.pr-title-prefix}}" >> "$GITHUB_ENV"
+        echo "PR_LABELS=${{inputs.pr-labels}}" >> "$GITHUB_ENV"
         echo "BRANCH_NAME_PREFIX=${{inputs.branch-name-prefix}}" >> "$GITHUB_ENV"
     # 差分があったときは、コミットを作りpushする
     - name: Push
@@ -92,7 +97,7 @@ runs:
         script: |
           const {script} = require('${{ github.action_path }}/dist/assign_a_user.js')
           await script(github, context)
-    # 修正PRのタイトルやDescriptionを更新する
+    # 修正PRのタイトルやDescription、ラベルを更新する
     - name: Update PullRequest
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       if: steps.diff.outputs.result != '' && ((github.event_name == 'pull_request' && github.event.action != 'closed') || github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch')

--- a/dist/update_pull_request.js
+++ b/dist/update_pull_request.js
@@ -4,20 +4,33 @@ exports.script = script;
 const generate_title_description_1 = require("./generate_title_description");
 const get_pull_requests_1 = require("./get_pull_requests");
 async function script(github, context) {
+    var _a;
     const { title, body } = (0, generate_title_description_1.generateTitleDescription)();
     for (const pull of await (0, get_pull_requests_1.getPullRequests)(github, context)) {
-        if (pull.title === title && pull.body === body) {
+        // PRのタイトルやDescriptionを更新する
+        if (pull.title !== title || pull.body !== body) {
+            const pullsUpdateParams = {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pull.number,
+                title,
+                body,
+            };
+            console.log("call pulls.update:", pullsUpdateParams);
+            await github.rest.pulls.update(pullsUpdateParams);
+        }
+        const labels = (_a = process.env.PR_LABELS) === null || _a === void 0 ? void 0 : _a.split(",");
+        if (labels === undefined || labels.length === 0) {
             continue;
         }
-        // PRのタイトルやDescriptionを更新する
-        const pullsUpdateParams = {
+        // ラベルを付与する
+        const issuesAddLabelsParams = {
             owner: context.repo.owner,
             repo: context.repo.repo,
-            pull_number: pull.number,
-            title,
-            body,
+            issue_number: pull.number,
+            labels,
         };
-        console.log("call pulls.update:", pullsUpdateParams);
-        await github.rest.pulls.update(pullsUpdateParams);
+        console.log("call issues.addLabels:", issuesAddLabelsParams);
+        await github.rest.issues.addLabels(issuesAddLabelsParams);
     }
 }


### PR DESCRIPTION
修正PRにラベルを付与できるようにします。
これにより、 `schedule` トリガーなど、PRをトリガーとしていないCIで作成された修正PRの種別を識別しやすくなります。