### PR TITLE
[codex] Fix format workflow for tsx 4.22.3 update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "textlint-rule-preset-ja-technical-writing": "12.0.2",
         "textlint-rule-terminology": "5.2.16",
         "tsc": "2.0.4",
-        "tsx": "4.22.1",
+        "tsx": "4.22.3",
         "typescript": "6.0.3"
       },
       "engines": {
@@ -8129,9 +8129,9 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.1.tgz",
-      "integrity": "sha512-TvncJykhxAzFCk0VQZKBTClall4Pm7qXDSodb6uxi8QFa8X8mT6ABjxxsQ2opDRYxG7AzcRWXaFtruz5HJKuWg==",
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "textlint-rule-preset-ja-technical-writing": "12.0.2",
     "textlint-rule-terminology": "5.2.16",
     "tsc": "2.0.4",
-    "tsx": "4.22.1",
+    "tsx": "4.22.3",
     "typescript": "6.0.3"
   },
   "engines": {

--- a/scripts/format/format/get_inputs_markdown.ts
+++ b/scripts/format/format/get_inputs_markdown.ts
@@ -1,5 +1,8 @@
+import { createRequire } from "module";
 import { readFileSync } from "fs";
-import * as yaml from "js-yaml";
+
+const require = createRequire(import.meta.url);
+const yaml = require("js-yaml") as typeof import("js-yaml");
 
 export function script(): string {
   const ymlFile = yaml.load(readFileSync("action.yml", "utf8")) as {


### PR DESCRIPTION
## Summary
- update `tsx` from `4.22.1` to `4.22.3`
- fix `scripts/format/format/get_inputs_markdown.ts` to load `js-yaml` via `createRequire()`
- keep the format workflow compatible with the `tsx/esm/api` path used by `actions/github-script`

## Root Cause
The `format` workflow failed in the `Get inputs markdown` step after the `tsx` update. On GitHub Actions, `tsImport()` loaded `get_inputs_markdown.ts` with a `?namespace=...` suffix, and the ESM import of `js-yaml` resolved to a non-existent path, causing `ERR_MODULE_NOT_FOUND`.

## Impact
This PR preserves the dependency update while restoring the workflow that regenerates the README input table during formatting.

## Validation
- `node -e "(async()=>{ const {tsImport}=require('tsx/esm/api'); const mod = await tsImport('./scripts/format/format/get_inputs_markdown.ts', process.cwd() + '/'); const target = mod.default || mod; console.log(target.script()); })().catch((err)=>{ console.error(err); process.exit(1); })"`
- `npx prettier --check scripts/format/format/get_inputs_markdown.ts`
- `node node_modules/typescript/bin/tsc --noEmit`
