### PR TITLE
コミット追加の注意文言を修正PRの説明に追加する

### DIFF
--- a/dist/generate_title_description.js
+++ b/dist/generate_title_description.js
@@ -27,6 +27,9 @@ function generateTitleDescription() {
     }
     body += "\n\n";
     body += `CIが再度実行されると本PR ( \`${escapedHead}\` ) にforce pushされます。\n`;
+    body += `> [!WARNING]\n`;
+    body += `> 本PR ( \`${escapedHead}\` ) にコミットを追加すると、CIが再度実行された際にコミットが消える場合があります。\n`;
+    body += `> コミットを追加したい場合は本PR ( \`${escapedHead}\` ) を起点に別途PRを立てることをおすすめします。\n`;
     body += "```mermaid\n";
     body += `%%{init: {'gitGraph': {'mainBranchName': '${escapedHeadRef}'}}}%%\n`;
     body += "gitGraph\n";

--- a/src/generate_title_description.ts
+++ b/src/generate_title_description.ts
@@ -35,6 +35,9 @@ export function generateTitleDescription(): {
 
   body += "\n\n";
   body += `CIが再度実行されると本PR ( \`${escapedHead}\` ) にforce pushされます。\n`;
+  body += `> [!WARNING]\n`;
+  body += `> 本PR ( \`${escapedHead}\` ) にコミットを追加すると、CIが再度実行された際にコミットが消える場合があります。\n`;
+  body += `> コミットを追加したい場合は本PR ( \`${escapedHead}\` ) を起点に別途PRを立てることをおすすめします。\n`;
   body += "```mermaid\n";
   body += `%%{init: {'gitGraph': {'mainBranchName': '${escapedHeadRef}'}}}%%\n`;
   body += "gitGraph\n";


### PR DESCRIPTION
修正PRにコミットを追加すると、再度CIが実行された際に消える場合があるので、それに対する注意文言を追加します。

修正PR例: https://github.com/dev-hato/actions-diff-pr-management/pull/2403