### PR TITLE
Takumiを使う

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -28,6 +28,8 @@ jobs:
           cache: npm
           node-version-file: .node-version
       - if: github.event_name != 'pull_request' || github.event.action != 'closed'
+        uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
+      - if: github.event_name != 'pull_request' || github.event.action != 'closed'
         run: npm install
       - name: Get inputs markdown
         id: get_inputs_markdown

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           cache: npm
           node-version-file: .node-version
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
       - run: bash "${GITHUB_WORKSPACE}/scripts/super_linter/build/set_path.sh"
       ################################
       # Run Linter against code base #

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 prefer-offline=true
 engine-strict=true
+registry=https://npm.flatt.tech/


### PR DESCRIPTION
GMOのTakumi ( https://flatt.tech/takumi/features/guard ) を使うと脆弱性があるパッケージのインストールをブロックしてくれるらしいので、CIに入れてみます。
`.npmrc` の設定の差分も含むため、手元でのインストール時にもTakumi経由で行われるようになります。